### PR TITLE
Customisable AWS Region

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ In order for Leader Selection to run a few environmental variables must be prese
 * **USE_CRON** = true -- Must be set in order for Leader Selection to occur. (This can be used to prevent Selection from occurring on undesired environments IE Workers, etc.)
 * **AWS_ACCESS_KEY_ID** -- Needed for read-only access to ec2 client
 * **AWS_SECRET_ACCESS_KEY** -- Needed for read-only access to ec2 client
+* **AWS_REGION** -- Sets which AWS region when looking using the ec2 client, defaults to `us-east-1` if not set.
  
 These can be included in your **.env** or, for EB, in the environment's configuration section.
 

--- a/src/Console/AWS/ConfigureLeaderCommand.php
+++ b/src/Console/AWS/ConfigureLeaderCommand.php
@@ -28,8 +28,11 @@ class ConfigureLeaderCommand extends Command
     public function __construct()
     {
         parent::__construct();
+
+        $region = getenv('AWS_REGION') ?: 'us-east-1';
+
         $client         = new Ec2Client([
-                                            'region'  => 'us-east-1',
+                                            'region'  => $region,
                                             'version' => 'latest'
                                         ]);
         $this->ecClient = $client;


### PR DESCRIPTION
Allows you to set a custom AWS region using the AWS_REGION environment variable. If this variable is not set it will default to us-east-1 (backwards compatible)
