### PR TITLE
Fixes issue with possible undefined index in certain circumstances

### DIFF
--- a/src/Console/AWS/ConfigureLeaderCommand.php
+++ b/src/Console/AWS/ConfigureLeaderCommand.php
@@ -101,7 +101,7 @@ class ConfigureLeaderCommand extends Command
                         })[0];
                     } else {
                         $this->info('Only one instance running...');
-                        $oldestInstance = $candidateInstances[0];
+                        $oldestInstance = reset($candidateInstances);
                     }
                     if ($oldestInstance['InstanceId'] == $result) {
                         // if this instance is the oldest instance it's the leader


### PR DESCRIPTION
Today whilst debugging another issue I encountered errors deploying to our development environment. Upon investigating line 104 of ConfigureLeaderCommand.php was erroring.

`$oldestInstance = $candidateInstances[0];`

Upon dumping this out I found the index of the only element in the array was `3`. I can only assume this means that AWS doesn't always return the only active server with a 0 index.

Using `reset()` will always return the first element in an array.
